### PR TITLE
Modified Giter8 template to reflect docs

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.2.6

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.10.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.11.0")

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.17
+sbt.version = 1.2.6

--- a/src/main/g8/src/main/scala/Hello.scala
+++ b/src/main/g8/src/main/scala/Hello.scala
@@ -1,3 +1,0 @@
-object Hello extends App {
-  println("Hello, World!")
-}

--- a/src/main/g8/src/main/scala/Main.scala
+++ b/src/main/g8/src/main/scala/Main.scala
@@ -1,0 +1,4 @@
+object Main {
+  def main(args: Array[String]): Unit =
+    println("Hello, world!")
+}


### PR DESCRIPTION
Scala Native works great on sbt `1.2.x` which is newer and better.
So it is better to change the suggested version.
It lines with the following PR to Scala Native docs: https://github.com/scala-native/scala-native/pull/1373
Starting with version `0.11.0` Giter8 supports sbt 1.x so I updated the template version too.