### PR TITLE
Multiple updates: copyright year(s), Scala Native 0.4.0, sbt, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sbt new scala-native/scala-native.g8
 
 License
 -------
-Written in 2017 by EPFL.
+Written in 2017-2021 by EPFL.
 To the extent possible under law, the author(s) have dedicated all copyright and
 related and neighboring rights to this template to the public domain worldwide.
 This template is distributed without any warranty. See

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.4.6

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.12.0")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")
 libraryDependencies += {
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.11.12"
+scalaVersion := "2.13.4"
 
 // Set to false or remove if you want to show stubs as linking errors
 nativeLinkStubs := true

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.3.13
+sbt.version = 1.4.6

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0-M2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")


### PR DESCRIPTION
We update the Scala Native g8 template to use contemporary software versions.
The copyright year is converted to a range, including the current year.