### PR TITLE
Update numerous versions; significantly, use Scala Native 0.4.5, Scala 3.1.3 and sbt 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sbt new scala-native/scala-native.g8
 
 License
 -------
-Written in 2017-2021 by EPFL.
+Written in 2017-2022 by EPFL.
 To the extent possible under law, the author(s) have dedicated all copyright and
 related and neighboring rights to this template to the public domain worldwide.
 This template is distributed without any warranty. See

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.6.2

--- a/project/giter8.sbt
+++ b/project/giter8.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.14.0")
 libraryDependencies += {
   "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 }

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,6 +1,3 @@
-scalaVersion := "2.13.7"
-
-// Set to false or remove if you want to show stubs as linking errors
-nativeLinkStubs := true
+scalaVersion := "3.1.3"
 
 enablePlugins(ScalaNativePlugin)

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.5.5
+sbt.version = 1.6.2

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.2")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.5")


### PR DESCRIPTION
Also updated copyright year and sbt-giter8 plugin version.