### PR TITLE
Update Scala & Scalanative, sbt is OK

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.3.0"
+scalaVersion := "3.3.1"
 
 enablePlugins(ScalaNativePlugin)
 

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.14")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.15")


### PR DESCRIPTION
Provide the current Scala and Scalanative versions.

Looks like scala-steward already upgraded the sbt version in the template (in two places)
to 1.9.4, so no concerns with latest CVE.