### PR TITLE
Update Scala Native, Scala, & sbt to current versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.8
+sbt.version = 1.9.9

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.3.1"
+scalaVersion := "3.4.1"
 
 enablePlugins(ScalaNativePlugin)
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.4.1"
+scalaVersion := "3.3.3" // A Long Term Support version.
 
 enablePlugins(ScalaNativePlugin)
 

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.9.8
+sbt.version = 1.9.9

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.16")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")


### PR DESCRIPTION
Improve the Scala Native 0.5.n first time user experience.

Update Scala Native to 0.5.1, Scala to 3.4.1, and sbt to 1.9.9.
