### PR TITLE
Update copyright, Scala Native, Scala, & sbt to current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As an alternative, you can use [scala-cli](https://scala-cli.virtuslab.org/).
 
 ## License
 -------
-Created by [EPFL](https://www.epfl.ch/labs/lamp/): 2017-2023
+Created by [EPFL](https://www.epfl.ch/labs/lamp/): 2017-2025
 
 To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this template to the public domain worldwide. This template is distributed without any warranty. See <http://creativecommons.org/publicdomain/zero/1.0/>.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.6
+sbt.version = 1.10.11

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.3.3" // A Long Term Support version.
+scalaVersion := "3.3.6" // A Long Term Support version.
 
 enablePlugins(ScalaNativePlugin)
 

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.6
+sbt.version = 1.10.11

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.7")


### PR DESCRIPTION
A user in the Scala Native Discourse channel reported that these 
were out of date and that Metals was recommending an update
to the latest Scala LTS version: Done.

I believe/hope that this will merge cleanly on top of pending PRs.

On a quick read, it looks like most of those will not be merged.
The scala-steward changes might mean I have to re-base after
them.

A week or so after Scala Native 0.5.8 is released, I'll have to
submit an update for that also.
