### PR TITLE
Update copyright, Scala Native, Scala,  sbt, ubuntu and macOS to current versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           cache: 'sbt'
     - name: Install common dependencies
       shell: bash
+      if: ${{ startsWith(matrix.os, 'macos') }}
       run: brew install sbt
     - name: Run tests (${{ matrix.os }}) Java ${{ matrix.java }}
       run: sbt g8Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
-          distribution: 'zulu'
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
           cache: 'sbt'
     - name: Install common dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,8 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
           cache: 'sbt'
+    - name: Install common dependencies
+      shell: bash
+      run: brew install sbt
     - name: Run tests (${{ matrix.os }}) Java ${{ matrix.java }}
       run: sbt g8Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-22.04, macos-13]
         java: [ '17' ]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, macos-13]
-        java: [ '17' ]
+        java: [ '21' ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout current branch (full)
       uses: actions/checkout@v3
     - name: Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
           cache: 'sbt'
     - name: Run tests (${{ matrix.os }}) Java ${{ matrix.java }}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.6
+sbt.version = 1.10.11

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "3.3.3" // A Long Term Support version.
+scalaVersion := "3.3.6" // A Long Term Support version.
 
 enablePlugins(ScalaNativePlugin)
 

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.10.6
+sbt.version = 1.10.11

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.1")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.7")


### PR DESCRIPTION
A user in the Scala Native Discourse channel reported that these versions
were out of date and that Metals was recommending an update
to the latest Scala LTS version: Done.

Also removed some bit rot from CI versions.

I believe/hope that this will merge cleanly on top of pending PRs.

On a quick read, it looks like most of those will not be merged.
The scala-steward changes might mean I have to re-base after
them.

I will need to submit another PR once SN 0.5.8 had been released and aged
for a fortnight.