### PR TITLE
Fix #19: Implement check-cla & check-lint

### DIFF
--- a/.github/workflows/check-cla.yml
+++ b/.github/workflows/check-cla.yml
@@ -1,0 +1,9 @@
+name: Check CLA
+on: [pull_request]
+jobs:
+  check-cla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: scala/cla-checker@v1
+        with:
+          author: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/check-lint.yml
+++ b/.github/workflows/check-lint.yml
@@ -1,0 +1,11 @@
+name: Check Lint
+on:
+  pull_request:
+jobs:
+  check-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: VirtusLab/scala-cli-setup@v1.8
+      - run: scala-cli fmt --check
+

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,1 @@
-<<<<<<< HEAD
 sbt.version = 1.11.3
-=======
-sbt.version = 1.10.11
->>>>>>> e8a1d1c (Update Scala Native, Scala, & sbt to current versions)


### PR DESCRIPTION
Fix #19 

* `check-cla` is long over due. All thing with time & maturity.  

* There is only one `.scala` file in this repository so `check-lint` might be a bit excessive, but it make the structure and
  logic of this repository similar to the that of the main Scala Native repository.